### PR TITLE
Negative values formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,16 +61,14 @@ currencyFormatter.format(1000000, {
 // => '1^000^000*0 @'
 
 // Different formatting for positive and negative values
-currencyFormatter.format(1000000, {
-  symbol: '@',
-  decimal: '*',
-  thousand: '^',
-  precision: 1,
+currencyFormatter.format(-10, {
   format: {
     pos: '%s%v' // %s is the symbol and %v is the value
-    neg: '-%s%v'
+    neg: '(%s%v)'
   }
 });
+
+// => -$10
 ```
 
 You could also get a list of all the currencies here using one of the following:

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ currencyFormatter.format(-10, {
   }
 });
 
-// => -$10
+// => ($10)
 ```
 
 You could also get a list of all the currencies here using one of the following:

--- a/README.md
+++ b/README.md
@@ -49,7 +49,6 @@ Advanced Usage
 Currency Formatter uses [accounting](https://github.com/openexchangerates/accounting.js) library under the hood, and you can use its options to override the default behavior.
 
 ```JAVASCRIPT
-
 var currencyFormatter = require('currency-formatter');
 currencyFormatter.format(1000000, {
   symbol: '@',
@@ -60,6 +59,18 @@ currencyFormatter.format(1000000, {
 });
 
 // => '1^000^000*0 @'
+
+// Different formatting for positive and negative values
+currencyFormatter.format(1000000, {
+  symbol: '@',
+  decimal: '*',
+  thousand: '^',
+  precision: 1,
+  format: {
+    pos: '%s%v' // %s is the symbol and %v is the value
+    neg: '-%s%v'
+  }
+});
 ```
 
 You could also get a list of all the currencies here using one of the following:

--- a/index.js
+++ b/index.js
@@ -38,22 +38,50 @@ exports.defaultCurrency = {
 
 exports.currencies = currencies
 
+var formatMapping = [
+  {
+    symbolOnLeft: true,
+    spaceBetweenAmountAndSymbol: false,
+    format: {
+      pos: '%s%v',
+      neg: '(%s%v)'
+    }
+  },
+  {
+    symbolOnLeft: true,
+    spaceBetweenAmountAndSymbol: true,
+    format: {
+      pos: '%s %v',
+      neg: '(%s %v)'
+    }
+  },
+  {
+    symbolOnLeft: false,
+    spaceBetweenAmountAndSymbol: false,
+    format: {
+      pos: '%v%s',
+      neg: '(%v%s)'
+    }
+  },
+  {
+    symbolOnLeft: false,
+    spaceBetweenAmountAndSymbol: true,
+    format: {
+      pos: '%v %s',
+      neg: '(%v %s)'
+    }
+  }
+]
+
 exports.format = function (value, options) {
   var currency = findCurrency(options.code) || exports.defaultCurrency
 
   var symbolOnLeft = currency.symbolOnLeft
   var spaceBetweenAmountAndSymbol = currency.spaceBetweenAmountAndSymbol
 
-  var format = ''
-  if (symbolOnLeft) {
-    format = spaceBetweenAmountAndSymbol
-              ? '%s %v'
-              : '%s%v'
-  } else {
-    format = spaceBetweenAmountAndSymbol
-              ? '%v %s'
-              : '%v%s'
-  }
+  var format = formatMapping.find(function(f) {
+    return f.symbolOnLeft == symbolOnLeft && f.spaceBetweenAmountAndSymbol == spaceBetweenAmountAndSymbol
+  }).format
 
   return accounting.formatMoney(value, {
     symbol: isUndefined(options.symbol)

--- a/index.js
+++ b/index.js
@@ -100,7 +100,7 @@ exports.format = function (value, options) {
               ? options.precision
               : currency.decimalDigits,
 
-    format: typeof options.format === 'string'
+    format: ['string', 'object'].indexOf(typeof options.format) > -1
               ? options.format
               : format
   })

--- a/index.js
+++ b/index.js
@@ -44,7 +44,7 @@ var formatMapping = [
     spaceBetweenAmountAndSymbol: false,
     format: {
       pos: '%s%v',
-      neg: '(%s%v)'
+      neg: '-%s%v'
     }
   },
   {
@@ -52,7 +52,7 @@ var formatMapping = [
     spaceBetweenAmountAndSymbol: true,
     format: {
       pos: '%s %v',
-      neg: '(%s %v)'
+      neg: '-%s %v'
     }
   },
   {
@@ -60,7 +60,7 @@ var formatMapping = [
     spaceBetweenAmountAndSymbol: false,
     format: {
       pos: '%v%s',
-      neg: '(%v%s)'
+      neg: '-%v%s'
     }
   },
   {
@@ -68,7 +68,7 @@ var formatMapping = [
     spaceBetweenAmountAndSymbol: true,
     format: {
       pos: '%v %s',
-      neg: '(%v %s)'
+      neg: '-%v %s'
     }
   }
 ]

--- a/test.js
+++ b/test.js
@@ -6,6 +6,11 @@ describe('format', () => {
   context('Default Options', () => {
     context('Symbol on the left', () => {
       context('No Space', () => {
+        it('Returns ($10.00) for -10', () => {
+          var result = currencyFormatter.format(-10, { code: 'USD' })
+          assert.equal(result, '($10.00)')
+        })
+
         it('Returns $10.00 for 10', () => {
           var result = currencyFormatter.format(10, { code: 'USD' })
           assert.equal(result, '$10.00')
@@ -33,6 +38,11 @@ describe('format', () => {
       })
 
       context('With Space', () => {
+        it('Returns ($ 10,00) for -10', () => {
+          var result = currencyFormatter.format(-10, { code: 'ARS' })
+          assert.equal(result, '($ 10,00)')
+        })
+
         it('Returns $ 10,00 for 10', () => {
           var result = currencyFormatter.format(10, { code: 'ARS' })
           assert.equal(result, '$ 10,00')
@@ -62,6 +72,11 @@ describe('format', () => {
 
     context('Symbol on the right', () => {
       context('No Space', () => {
+        it('Returns (10.00Nfk) for -10', () => {
+          var result = currencyFormatter.format(-10, { code: 'ERN' })
+          assert.equal(result, '(10.00Nfk)')
+        })
+
         it('Returns 10.00Nfk for 10', () => {
           var result = currencyFormatter.format(10, { code: 'ERN' })
           assert.equal(result, '10.00Nfk')
@@ -89,6 +104,11 @@ describe('format', () => {
       })
 
       context('With Space', () => {
+        it('Returns (10,00 €) for -10', () => {
+          var result = currencyFormatter.format(-10, { code: 'EUR' })
+          assert.equal(result, '(10,00 €)')
+        })
+
         it('Returns 10,00 € for 10', () => {
           var result = currencyFormatter.format(10, { code: 'EUR' })
           assert.equal(result, '10,00 €')

--- a/test.js
+++ b/test.js
@@ -151,6 +151,30 @@ describe('format', () => {
       assert.equal(result, '1^000^000*000 ¯\\_(ツ)_/¯')
     })
 
+    it('Supports objects for format, to override the positive result', () => {
+      var result = currencyFormatter.format(10, {
+        code: 'USD',
+        format: {
+          pos: '%s  %v',
+          neg: '-%s%v'
+        }
+      })
+
+      assert.equal(result, '$  10.00')
+    })
+
+    it('Supports objects for format, to override the negative result', () => {
+      var result = currencyFormatter.format(-10, {
+        code: 'USD',
+        format: {
+          pos: '%s  %v',
+          neg: '-%s%v'
+        }
+      })
+
+      assert.equal(result, '-$10.00')
+    })
+
     it('Supports empty symbol', () => {
       var result = currencyFormatter.format(1000000, {
         code: 'USD',

--- a/test.js
+++ b/test.js
@@ -6,9 +6,9 @@ describe('format', () => {
   context('Default Options', () => {
     context('Symbol on the left', () => {
       context('No Space', () => {
-        it('Returns ($10.00) for -10', () => {
+        it('Returns -$10.00 for -10', () => {
           var result = currencyFormatter.format(-10, { code: 'USD' })
-          assert.equal(result, '($10.00)')
+          assert.equal(result, '-$10.00')
         })
 
         it('Returns $10.00 for 10', () => {
@@ -38,9 +38,9 @@ describe('format', () => {
       })
 
       context('With Space', () => {
-        it('Returns ($ 10,00) for -10', () => {
+        it('Returns -$ 10,00 for -10', () => {
           var result = currencyFormatter.format(-10, { code: 'ARS' })
-          assert.equal(result, '($ 10,00)')
+          assert.equal(result, '-$ 10,00')
         })
 
         it('Returns $ 10,00 for 10', () => {
@@ -72,9 +72,9 @@ describe('format', () => {
 
     context('Symbol on the right', () => {
       context('No Space', () => {
-        it('Returns (10.00Nfk) for -10', () => {
+        it('Returns -10.00Nfk for -10', () => {
           var result = currencyFormatter.format(-10, { code: 'ERN' })
-          assert.equal(result, '(10.00Nfk)')
+          assert.equal(result, '-10.00Nfk')
         })
 
         it('Returns 10.00Nfk for 10', () => {
@@ -104,9 +104,9 @@ describe('format', () => {
       })
 
       context('With Space', () => {
-        it('Returns (10,00 €) for -10', () => {
+        it('Returns -10,00 € for -10', () => {
           var result = currencyFormatter.format(-10, { code: 'EUR' })
-          assert.equal(result, '(10,00 €)')
+          assert.equal(result, '-10,00 €')
         })
 
         it('Returns 10,00 € for 10', () => {
@@ -168,11 +168,11 @@ describe('format', () => {
         code: 'USD',
         format: {
           pos: '%s  %v',
-          neg: '-%s%v'
+          neg: '(%s%v)'
         }
       })
 
-      assert.equal(result, '-$10.00')
+      assert.equal(result, '($10.00)')
     })
 
     it('Supports empty symbol', () => {


### PR DESCRIPTION
Issue: #24 

* Displaying `-$10` instead of `$-10` by default (https://github.com/smirzaei/currency-formatter/blob/5cd9ba87bd285e32b184594542f7479118a65b0a/test.js#L9-L12)
* Allowing the user to override negative formatting (https://github.com/smirzaei/currency-formatter/blob/5cd9ba87bd285e32b184594542f7479118a65b0a/test.js#L166-L176)

This could be improved one step further by taking a flag whether the user wants the negative values to be displayed like `($10)` or `-$10` so they wouldn't have to override the `format` option everywhere. If it is something you need then feel free to open an issue.