### PR TITLE
Danish currency

### DIFF
--- a/currencies.js
+++ b/currencies.js
@@ -344,9 +344,9 @@ module.exports = [
   {
     code: 'DKK',
     symbol: 'kr.',
-    thousandsSeparator: '.',
+    thousandsSeparator: '',
     decimalSeparator: ',',
-    symbolOnLeft: true,
+    symbolOnLeft: false,
     spaceBetweenAmountAndSymbol: true,
     decimalDigits: 2
   },


### PR DESCRIPTION
Danish currency is not divided by a . on the thousands and the symbol is on the right not the left.