### PR TITLE
Fix ZAR formatting

### DIFF
--- a/currencies.json
+++ b/currencies.json
@@ -1424,10 +1424,10 @@
   "ZAR": {
     "code": "ZAR",
     "symbol": "R",
-    "thousandsSeparator": ",",
-    "decimalSeparator": ".",
+    "thousandsSeparator": " ",
+    "decimalSeparator": ",",
     "symbolOnLeft": true,
-    "spaceBetweenAmountAndSymbol": true,
+    "spaceBetweenAmountAndSymbol": false,
     "decimalDigits": 2
   },
   "ZMW": {


### PR DESCRIPTION
ZAR uses "continental" formatting (e.g R5 000,00)