### PR TITLE
Allow using only language code as locale

### DIFF
--- a/index.js
+++ b/index.js
@@ -56,7 +56,9 @@ var formatMapping = [
 
 function format(value, options) {
   var code = options.code || (options.locale && localeCurrency.getCurrency(options.locale))
-  var [, language, ,region] = /^([a-z]+)([_-]([a-z]+))?$/i.exec(options.locale) || []
+  var localeMatch = /^([a-z]+)([_-]([a-z]+))?$/i.exec(options.locale) || []
+  var language = localeMatch[1]
+  var region = localeMatch[3]
   var localeFormat = assign({}, defaultLocaleFormat,
                             localeFormats[language] || {},
                             localeFormats[`${language}-${region}`] || {})

--- a/index.js
+++ b/index.js
@@ -61,7 +61,7 @@ function format(value, options) {
   var region = localeMatch[3]
   var localeFormat = assign({}, defaultLocaleFormat,
                             localeFormats[language] || {},
-                            localeFormats[`${language}-${region}`] || {})
+                            localeFormats[language + '-' + region] || {})
   var currency = assign({}, defaultCurrency, findCurrency(code), localeFormat)
   
   var symbolOnLeft = currency.symbolOnLeft

--- a/index.js
+++ b/index.js
@@ -56,7 +56,10 @@ var formatMapping = [
 
 function format(value, options) {
   var code = options.code || (options.locale && localeCurrency.getCurrency(options.locale))
-  var localeFormat = localeFormats[options.locale] || defaultLocaleFormat
+  var [, language, ,region] = /^([a-z]+)([_-]([a-z]+))?$/i.exec(options.locale) || []
+  var localeFormat = assign({}, defaultLocaleFormat,
+                            localeFormats[language] || {},
+                            localeFormats[`${language}-${region}`] || {})
   var currency = assign({}, defaultCurrency, findCurrency(code), localeFormat)
   
   var symbolOnLeft = currency.symbolOnLeft

--- a/localeFormats.json
+++ b/localeFormats.json
@@ -1,12 +1,12 @@
 {
-  "de-AT": {
+  "de": {
     "thousandsSeparator": ".",
     "decimalSeparator": ",",
     "symbolOnLeft": false,
     "spaceBetweenAmountAndSymbol": true,
     "decimalDigits": 2
   },
-  "el-GR": {
+  "el": {
     "symbolOnLeft": true,
     "spaceBetweenAmountAndSymbol": false,
     "thousandsSeparator": ".",
@@ -20,37 +20,23 @@
     "spaceBetweenAmountAndSymbol": true,
     "decimalDigits": 2
   },
-  "es-ES": {
+  "es": {
     "thousandsSeparator": ".",
     "decimalSeparator": ",",
     "symbolOnLeft": false,
     "spaceBetweenAmountAndSymbol": true,
     "decimalDigits": 2
   },
-  "it-IT": {
+  "it": {
     "symbolOnLeft": true,
     "spaceBetweenAmountAndSymbol": false,
     "thousandsSeparator": ".",
     "decimalSeparator": ",",
     "decimalDigits": 2
   },
-  "nl-NL": {
+  "nl": {
     "symbolOnLeft": true,
     "spaceBetweenAmountAndSymbol": false,
-    "thousandsSeparator": ".",
-    "decimalSeparator": ",",
-    "decimalDigits": 2
-  },
-  "nl-BE": {
-    "symbolOnLeft": true,
-    "spaceBetweenAmountAndSymbol": false,
-    "thousandsSeparator": ".",
-    "decimalSeparator": ",",
-    "decimalDigits": 2
-  },
-  "de-DE": {
-    "symbolOnLeft": false,
-    "spaceBetweenAmountAndSymbol": true,
     "thousandsSeparator": ".",
     "decimalSeparator": ",",
     "decimalDigits": 2

--- a/test.js
+++ b/test.js
@@ -158,9 +158,25 @@ describe('format', () => {
   })
 
   context('With locale option', () => {
+    it('Returns 1 234,56 € for fi', () => {
+      var result = currencyFormatter.format(1234.56, {
+        locale: 'fi'
+      })
+
+      assert.equal(result, '1 234,56 €')
+    })
+
     it('Returns €1.234,56 for nl-NL', () => {
       var result = currencyFormatter.format(1234.56, {
         locale: 'nl-NL'
+      })
+
+      assert.equal(result, '€1.234,56')
+    })
+
+    it('Returns €1.234,56 for nl', () => {
+      var result = currencyFormatter.format(1234.56, {
+        locale: 'nl'
       })
 
       assert.equal(result, '€1.234,56')


### PR DESCRIPTION
This makes locale's region parameter optional. It allows less
duplication with locale definitions.