### PR TITLE
Fix the symbol of CHF

### DIFF
--- a/currencies.json
+++ b/currencies.json
@@ -253,7 +253,7 @@
   },
   "CHF": {
     "code": "CHF",
-    "symbol": "CHF",
+    "symbol": "Fr",
     "thousandsSeparator": "'",
     "decimalSeparator": ".",
     "symbolOnLeft": false,


### PR DESCRIPTION
According to https://en.wikipedia.org/wiki/Swiss_franc
the symbol of CHF should be `Fr`