### PR TITLE
fix: update CHF to use currency code instead of 'fr'

### DIFF
--- a/currencies.json
+++ b/currencies.json
@@ -253,10 +253,10 @@
   },
   "CHF": {
     "code": "CHF",
-    "symbol": "Fr",
+    "symbol": "CHF",
     "thousandsSeparator": "'",
     "decimalSeparator": ".",
-    "symbolOnLeft": false,
+    "symbolOnLeft": true,
     "spaceBetweenAmountAndSymbol": true,
     "decimalDigits": 2
   },


### PR DESCRIPTION
According to the Internationalisation APIs, the standard format for Switzerland is as follows:

```
new Intl.NumberFormat('de-CH', { style: 'currency', currency: 'CHF' }).format(1000000)
"CHF 1’000’000.00"

```

I've updated `currencies.json` so that the format is correct