### PR TITLE
fix: updated currency symbol for Georgia

### DIFF
--- a/currencies.json
+++ b/currencies.json
@@ -433,7 +433,7 @@
   },
   "GEL": {
     "code": "GEL",
-    "symbol": "Lari",
+    "symbol": "GEL",
     "thousandsSeparator": " ",
     "decimalSeparator": ",",
     "symbolOnLeft": false,


### PR DESCRIPTION
We are using this project for our currency formatting and currency symbol rendering. The `Intl` is not a good use case because they render a symbol in the locale namespaces (that will give you different symbols for different locales, e.g., `RUB` (in EN locale) and `₽` in RU locale).

We now have problems with Georgian currency, when our partners in Georgia claim that no one uses `Lari` as a symbol (and they said that people could be confused with `Lari`), so they prefer to use `GEL` (some references that this is also ISO standardized under ISO-4217 reference - https://www1.oanda.com/currency/iso-currency-codes/GEL)