### PR TITLE
Update currencies.json updated CLP decimal digits

### DIFF
--- a/currencies.json
+++ b/currencies.json
@@ -276,7 +276,7 @@
     "decimalSeparator": ",",
     "symbolOnLeft": true,
     "spaceBetweenAmountAndSymbol": true,
-    "decimalDigits": 2
+    "decimalDigits": 0
   },
   "CNY": {
     "code": "CNY",


### PR DESCRIPTION
I updated CLP decimal digits, since it is wrong currently has 2 decimal digits while CLP uses none. 